### PR TITLE
Make Rotary Encoder Switch Configurable to be Activ Low/High

### DIFF
--- a/components/rotary_encoder/include/rotary_encoder.h
+++ b/components/rotary_encoder/include/rotary_encoder.h
@@ -30,13 +30,13 @@ typedef void *rotary_encoder_dev_t;
  * 
  */
 typedef enum {
-	/** Press event issued */
-	ENC_IDLE = 0,
+    /** Press event issued */
+    ENC_IDLE = 0,
     ENC_UP,
     ENC_DOWN,
     ENC_BUT_SHORT_PRESS,
     ENC_BUT_LONG_PRESS,
-    ENC_BUT_DOUBLE_PRESS,	
+    ENC_BUT_DOUBLE_PRESS, 
 } encoder_state_t;
 
 /** 
@@ -44,12 +44,12 @@ typedef enum {
  * 
  */
 typedef enum {
-	S_IDLE = 0,
+    S_IDLE = 0,
     S_BUTTON_PRESSED,
     S_BUTTON_RELEASED,
     S_LONG_PRESSED,
     S_DOUBLE_PRESSED
-	
+ 
 } encoder_fsm_t;
 
 /**
@@ -61,6 +61,7 @@ typedef struct {
     int phase_a_gpio_num;     /*!< Phase A GPIO number */
     int phase_b_gpio_num;     /*!< Phase B GPIO number */
     int button_gpio_num;      /*!< Button GPIO number  */
+    int button_active_low;    /*!< Button ActiveLow=1 ActiveHigh=0=default */
     int flags;                /*!< Extra flags */
 } rotary_encoder_config_t;
 
@@ -68,13 +69,14 @@ typedef struct {
  * @brief Default rotary encoder configuration
  *
  */
-#define ROTARY_ENCODER_DEFAULT_CONFIG(dev_hdl, gpio_a, gpio_b, gpio_pin) \
-    {                                                          \
-        .dev = dev_hdl,                                        \
-        .phase_a_gpio_num = gpio_a,                            \
-        .phase_b_gpio_num = gpio_b,                            \
-        .button_gpio_num = gpio_pin,                            \
-        .flags = 0,                                            \
+#define ROTARY_ENCODER_DEFAULT_CONFIG(dev_hdl, gpio_a, gpio_b, gpio_pin, button_al) \
+    {                                                                               \
+        .dev = dev_hdl,                                                             \
+        .phase_a_gpio_num = gpio_a,                                                 \
+        .phase_b_gpio_num = gpio_b,                                                 \
+        .button_gpio_num = gpio_pin,                                                \
+        .button_active_low = button_al,                                             \
+        .flags = 0,                                                                 \
     }
 
 /**
@@ -137,6 +139,7 @@ struct rotary_encoder_t {
      */
     int (*get_counter_value)(rotary_encoder_t *encoder);
     int32_t encoder_s_pin;
+    int8_t encoder_s_active_low;
     int16_t last_encoder_count;
     encoder_fsm_t fsm_state;
     uint32_t fsm_timer;

--- a/docs/knob-configuration.md
+++ b/docs/knob-configuration.md
@@ -29,3 +29,9 @@ uint16_t default_encoder_map[LAYERS][ENCODER_SIZE] = {
 	{ KC_AUDIO_VOL_DOWN, KC_AUDIO_VOL_UP, KC_AUDIO_MUTE, KC_MEDIA_PLAY_PAUSE, KC_MEDIA_NEXT_TRACK }
 };
 ```
+
+If you use other than the default rotary encoders which have an active low switch, you can adjust the behavior of the switch in the `keyboard_config.h` file.
+
+```c
+ #define ENCODER1_S_ACTIVE_LOW 1	   // encoder switch is active_low=1 active_high=0
+```

--- a/main/keyboard_config.h
+++ b/main/keyboard_config.h
@@ -42,12 +42,14 @@
 #define ENCODER1_A_PIN GPIO_NUM_26 // encoder phase A pin
 #define ENCODER1_B_PIN GPIO_NUM_25// encoder phase B pin
 #define ENCODER1_S_PIN GPIO_NUM_34// encoder switch pin
+#define ENCODER1_S_ACTIVE_LOW 1	  // encoder switch is active_low=1 active_high=0
 
 
 #define R_ENCODER_2 // undefine if no rotary encoder is used
 #define ENCODER2_A_PIN GPIO_NUM_33// encoder phase A pin
 #define ENCODER2_B_PIN GPIO_NUM_32// encoder phase B pin
 #define ENCODER2_S_PIN GPIO_NUM_27// encoder switch pin
+#define ENCODER2_S_ACTIVE_LOW 0	  // encoder switch is active_low=1 active_high=0
 
 #define RGB_LEDS
 

--- a/main/keyboard_config.h
+++ b/main/keyboard_config.h
@@ -42,7 +42,7 @@
 #define ENCODER1_A_PIN GPIO_NUM_26 // encoder phase A pin
 #define ENCODER1_B_PIN GPIO_NUM_25// encoder phase B pin
 #define ENCODER1_S_PIN GPIO_NUM_34// encoder switch pin
-#define ENCODER1_S_ACTIVE_LOW 1	  // encoder switch is active_low=1 active_high=0
+#define ENCODER1_S_ACTIVE_LOW 0	  // encoder switch is active_low=1 active_high=0
 
 
 #define R_ENCODER_2 // undefine if no rotary encoder is used

--- a/main/mk32_main.cpp
+++ b/main/mk32_main.cpp
@@ -439,7 +439,7 @@ extern "C" void app_main() {
 
     // Create rotary encoder instance
     rotary_encoder_config_t config_a = \
-		ROTARY_ENCODER_DEFAULT_CONFIG((rotary_encoder_dev_t)pcnt_unit_a, ENCODER1_A_PIN, ENCODER1_B_PIN, ENCODER1_S_PIN);
+		ROTARY_ENCODER_DEFAULT_CONFIG((rotary_encoder_dev_t)pcnt_unit_a, ENCODER1_A_PIN, ENCODER1_B_PIN, ENCODER1_S_PIN, ENCODER1_S_ACTIVE_LOW);
     ESP_ERROR_CHECK(rotary_encoder_new_ec11(&config_a, &encoder_a));
 
     // Filter out glitch (1us)
@@ -458,7 +458,7 @@ extern "C" void app_main() {
 
     // Create rotary encoder instance
     rotary_encoder_config_t config_b = \
-			ROTARY_ENCODER_DEFAULT_CONFIG((rotary_encoder_dev_t)pcnt_unit_b, ENCODER2_A_PIN, ENCODER2_B_PIN, ENCODER2_S_PIN);
+			ROTARY_ENCODER_DEFAULT_CONFIG((rotary_encoder_dev_t)pcnt_unit_b, ENCODER2_A_PIN, ENCODER2_B_PIN, ENCODER2_S_PIN, ENCODER2_S_ACTIVE_LOW);
     ESP_ERROR_CHECK(rotary_encoder_new_ec11(&config_b, &encoder_b));
 
     // Filter out glitch (1us)


### PR DESCRIPTION
**Why?**
I am using different rotary encoder, with integrated Pull Up resistors. So the button logic doesn't work anymore.

**What?**
This PR fixes it as it makes the switch behavior configurable to be active high or active low.

**Possible Improvements**
Maybe also the `flags` field of the `rotary_encoder_dev_t` struct can be used, so no extra field is needed, but I couldn't figure out for what the flags are used. 

This is my first PR, so feedback is very appreciated :smile:. Also, sorry about the whitespace changes, maybe a common formatting style should be used.