### PR TITLE
Fix previous track value Fixes #4

### DIFF
--- a/components/rotary_encoder/src/rotary_encoder_pcnt_ec11.c
+++ b/components/rotary_encoder/src/rotary_encoder_pcnt_ec11.c
@@ -346,7 +346,7 @@ void encoder_command(uint8_t command, uint16_t encoder_commands[ENCODER_SIZE]){
                 break;
 
                 case KC_MEDIA_PREV_TRACK:
-                    media_state[1] = 111;
+                    media_state[1] = 11;
                 break;
 
                 case KC_MEDIA_STOP:

--- a/main/gesture_handles.c
+++ b/main/gesture_handles.c
@@ -180,7 +180,7 @@ void gesture_command(uint8_t command, uint16_t gesture_commands[GESTURE_SIZE]) {
 				break;
 
 			case KC_MEDIA_PREV_TRACK:
-				media_state[1] = 111;
+				media_state[1] = 11;
 				break;
 
 			case KC_MEDIA_STOP:

--- a/main/keypress_handles.c
+++ b/main/keypress_handles.c
@@ -89,7 +89,7 @@ void media_control_send(uint16_t keycode) {
 		media_state[1] = 10;
 	}
 	if (keycode == KC_MEDIA_PREV_TRACK) {
-		media_state[1] = 111;
+		media_state[1] = 11;
 	}
 	if (keycode == KC_MEDIA_STOP) {
 		media_state[1] = 12;


### PR DESCRIPTION
Send `11` instead of `111` for previous track.  With a value of `111` it seemed to be sending a right-click instead of "previous track"

Note, I'm using my DeepDeck on a Mac, so I don't know if the behavior I was seeing was a Mac-only issue.