### PR TITLE
Adding a clamp to the max brightness, and variables for the solid colors

### DIFF
--- a/components/rgb_led/include/rgb_led.h
+++ b/components/rgb_led/include/rgb_led.h
@@ -33,6 +33,12 @@
 #define NOTIFICATION_RGB_GPIO   23
 #define RGB_LED_KEYBOARD_NUMBER 16
 #define RGB_LED_NOTIFICATION_NUMBER 2
+// The maximum brightness that the LEDs can be set to using the hsv2rgb function
+#define MAX_BRIGHTNESS 16
+// Colors for the solid color mode
+#define SOLID_RED 0
+#define SOLID_GREEN 85
+#define SOLID_BLUE 170
 
 /** @brief Queue for sending mouse reports
  * @see mouse_command_t */


### PR DESCRIPTION
Adding a clamp to the max brightness in the hsv2rgb function, to not make the LEDs too bright. Along with adding some definitions to make the changing of the solid color fewer changes. Also a fix that makes the upper leds change along with the rest of the keys instead of just on the pulsating mode.