### PR TITLE
Fix crashes when oled or RGB leds are absent

### DIFF
--- a/main/server.c
+++ b/main/server.c
@@ -926,17 +926,18 @@ esp_err_t delete_layer_url_handler(httpd_req_t *req)
 		httpd_resp_sendstr(req, string);
 		httpd_resp_set_status(req, HTTPD_200);
 		httpd_resp_send(req, NULL, 0);
-		xQueueSend(layer_recieve_q, &current_layout,
-				   (TickType_t)0);
 	}
 	else
 	{
 		// TODO: Handle error -> maximum number of layers reached
-		xQueueSend(layer_recieve_q, &current_layout,
-				   (TickType_t)0);
 		httpd_resp_set_status(req, HTTPD_400);
 		httpd_resp_send(req, NULL, 0);
 	}
+
+#ifdef OLED_ENABLE
+	xQueueSend(layer_recieve_q, &current_layout,
+			   (TickType_t)0);
+#endif
 
 	return ESP_OK;
 }
@@ -1166,12 +1167,16 @@ esp_err_t update_layer_url_handler(httpd_req_t *req)
 	httpd_resp_send(req, NULL, 0);
 
 	current_layout = 0;
+#ifdef OLED_ENABLE
 	xQueueSend(layer_recieve_q, &current_layout,
 			   (TickType_t)0);
+#endif
 
+#ifdef RGB_LEDS
 	rgb_mode_t led_mode;
 	nvs_load_led_mode(&led_mode);
 	xQueueSend(keyled_q, &led_mode, 0);
+#endif
 
 	return ESP_OK;
 }
@@ -1340,8 +1345,10 @@ esp_err_t create_layer_url_handler(httpd_req_t *req)
 	free(buf);
 	current_layout = 0;
 	res = nvs_create_new_layer(new_layer);
+#ifdef RGB_LEDS
 	rgb_mode_t led_mode;
 	nvs_load_led_mode(&led_mode);
+#endif
 
 	if (res == ESP_OK)
 	{
@@ -1349,20 +1356,21 @@ esp_err_t create_layer_url_handler(httpd_req_t *req)
 		httpd_resp_sendstr(req, string);
 		httpd_resp_set_status(req, HTTPD_200);
 		httpd_resp_send(req, NULL, 0);
-		xQueueSend(layer_recieve_q, &current_layout,
-				   (TickType_t)0);
-
+#ifdef RGB_LEDS
 		xQueueSend(keyled_q, &led_mode, 0);
+#endif
 	}
 	else
 	{
 		// TODO: Handle error -> maximum number of layers reached
-		xQueueSend(layer_recieve_q, &current_layout,
-				   (TickType_t)0);
 		httpd_resp_set_status(req, HTTPD_400);
 		httpd_resp_send(req, NULL, 0);
 	}
 
+#ifdef OLED_ENABLE
+	xQueueSend(layer_recieve_q, &current_layout,
+			   (TickType_t)0);
+#endif
 	return ESP_OK;
 }
 
@@ -1415,12 +1423,16 @@ esp_err_t restore_default_layer_url_handler(httpd_req_t *req)
 	}
 
 	current_layout = 0;
+#ifdef OLED_ENABLE
 	xQueueSend(layer_recieve_q, &current_layout,
 			   (TickType_t)0);
+#endif
 
+#ifdef RGB_LEDS
 	rgb_mode_t led_mode;
 	nvs_load_led_mode(&led_mode);
 	xQueueSend(keyled_q, &led_mode, 0);
+#endif
 
 	return ESP_OK;
 }

--- a/main/wifi_handles.c
+++ b/main/wifi_handles.c
@@ -139,7 +139,9 @@ void wifi_init_softap(void)
 			 EXAMPLE_ESP_WIFI_SSID, EXAMPLE_ESP_WIFI_PASS,
 			 EXAMPLE_ESP_WIFI_CHANNEL);
 	wifi_ap_mode = true;
+#ifdef OLED_DISPLAY
 	wifi_connected_oled("AP_MODE");
+#endif
 }
 //////////////////////////////////////////////////////////////////////////
 
@@ -175,7 +177,9 @@ void event_handler(void *arg, esp_event_base_t event_base,
 		char ip_char[16] = {0}; // 16 es el tamaño máximo de una dirección IP
 		sprintf(ip_char, "%d.%d.%d.%d", esp_ip4_addr1_16(&event->ip_info.ip), esp_ip4_addr2_16(&event->ip_info.ip), esp_ip4_addr3_16(&event->ip_info.ip), esp_ip4_addr4_16(&event->ip_info.ip));
 
+#ifdef OLED_DISPLAY
 		wifi_connected_oled(ip_char);
+#endif
 		s_retry_num = 0;
 		xEventGroupSetBits(s_wifi_event_group, WIFI_CONNECTED_BIT);
 	}


### PR DESCRIPTION
Hi,

I had the opportunity to work on a simplified version of the DeepDeck, which didn't include a screen or RGB leds. The following adjustements were required in order to make the firmware v0.5.7 work:

- Commit d0e4911 fix a crash on startup, once the wifi task is loaded.
- Commit e58c5e7 fix a crash when updating the configuration through the web interface. The update was taken into account, but a hard reset was required afterward.